### PR TITLE
增加消息内链接跳转方式

### DIFF
--- a/src/Message/ActionCardMessage.php
+++ b/src/Message/ActionCardMessage.php
@@ -87,13 +87,14 @@ class ActionCardMessage extends Message
      *
      * @param string $singleTitle 单个按钮的方案。(设置此项和singleURL后btns无效。)
      * @param string $singleUrl   点击singleTitle按钮触发的URL
+     * @param bool   $pcSlide     链接在钉钉侧栏打开，false则在浏览器打开
      *
      * @return $this
      */
-    public function setSingle(string $singleTitle, string $singleUrl): self
+    public function setSingle(string $singleTitle, string $singleUrl, bool $pcSlide = true): self
     {
         $this->message['actionCard']['singleTitle'] = $singleTitle;
-        $this->message['actionCard']['singleURL'] = $singleUrl;
+        $this->message['actionCard']['singleURL'] = $this->getFinalUrl($singleUrl, $pcSlide);
         unset($this->message['actionCard']['btns']);
 
         return $this;
@@ -104,14 +105,15 @@ class ActionCardMessage extends Message
      *
      * @param string $title     按钮方案
      * @param string $actionUrl 点击按钮触发的URL
+     * @param bool   $pcSlide   链接在钉钉侧栏打开，false则在浏览器打开
      *
      * @return ActionCardMessage
      */
-    public function addButton(string $title, string $actionUrl): self
+    public function addButton(string $title, string $actionUrl, bool $pcSlide = true): self
     {
         $this->message['actionCard']['btns'][] = [
             'title'     => $title,
-            'actionURL' => $actionUrl,
+            'actionURL' => $this->getFinalUrl($actionUrl, $pcSlide),
         ];
         unset($this->message['actionCard']['singleTitle']);
         unset($this->message['actionCard']['singleURL']);

--- a/src/Message/FeedCardMessage.php
+++ b/src/Message/FeedCardMessage.php
@@ -33,15 +33,16 @@ class FeedCardMessage extends Message
      * @param string $title      单条信息文本
      * @param string $messageUrl 点击单条信息到跳转链接
      * @param string $picUrl     单条信息后面图片的URL
+     * @param bool   $pcSlide    链接在钉钉侧栏打开，false则在浏览器打开
      *
      * @return FeedCardMessage
      */
-    public function addLink(string $title, string $messageUrl, string $picUrl): self
+    public function addLink(string $title, string $messageUrl, string $picUrl, bool $pcSlide = true): self
     {
         $this->message['feedCard']['links'][] = [
             'title'      => $title,
-            'messageURL' => $messageUrl,
-            'picURL'     => $picUrl,
+            'messageURL' => $this->getFinalUrl($messageUrl, $pcSlide),
+            'picURL'     => $this->getFinalUrl($picUrl, $pcSlide),
         ];
 
         return $this;

--- a/src/Message/LinkMessage.php
+++ b/src/Message/LinkMessage.php
@@ -33,18 +33,19 @@ class LinkMessage extends Message
      * @param string $text       消息内容。如果太长只会部分展示
      * @param string $messageUrl 点击消息跳转的 URL
      * @param string $picUrl     图片 URL
+     * @param bool   $pcSlide    链接在钉钉侧栏打开，false则在浏览器打开
      *
      * @return LinkMessage
      */
-    public function setMessage(string $title, string $text, string $messageUrl, string $picUrl = ''): self
+    public function setMessage(string $title, string $text, string $messageUrl, string $picUrl = '', bool $pcSlide = true): self
     {
         $this->message = [
             'msgtype' => 'link',
             'link'    => [
                 'title'      => $title,
                 'text'       => $text,
-                'picUrl'     => $picUrl,
-                'messageUrl' => $messageUrl,
+                'picUrl'     => $this->getFinalUrl($picUrl, $pcSlide),
+                'messageUrl' => $this->getFinalUrl($messageUrl, $pcSlide),
             ],
         ];
 

--- a/src/Message/Message.php
+++ b/src/Message/Message.php
@@ -19,6 +19,18 @@ abstract class Message
     protected $robot = 'default';
 
     /**
+     * 获取最终URL.
+     * @param  string  $url
+     * @param  bool  $pcSlide
+     *
+     * @return string
+     */
+    public function getFinalUrl($url, $pcSlide = true): string
+    {
+        return sprintf('dingtalk://dingtalkclient/page/link?url=%s&pc_slide=%s', urlencode($url), $pcSlide ? 'true' : 'false');
+    }
+
+    /**
      * 获取消息请求的请求体内容.
      *
      * @return array


### PR DESCRIPTION
消息打开方式默认在钉钉侧栏打开，支持设置为浏览器打开
from: https://github.com/zhuifengshen/DingtalkChatbot